### PR TITLE
Chore/docker efficiency update

### DIFF
--- a/Dockerfile.backend.dev
+++ b/Dockerfile.backend.dev
@@ -8,15 +8,15 @@ WORKDIR /app
 
 COPY package.json yarn.lock tsconfig.json .yarnrc.yml ./
 COPY apps/backend/package.json apps/backend/tsconfig.json ./apps/backend/
+COPY common/types/package.json common/types/tsconfig.json ./common/types/
+COPY common/json-data/package.json common/json-data/tsconfig.json ./common/json-data/
+COPY common/validation/package.json common/validation/tsconfig.json ./common/validation/
+RUN corepack enable && yarn install
 COPY apps/backend/src/ ./apps/backend/src/
 COPY apps/backend/test-helpers/ ./apps/backend/test-helpers/
-COPY common/types/package.json common/types/tsconfig.json ./common/types/
 COPY common/types/src/ ./common/types/src/
-COPY common/json-data/package.json common/json-data/tsconfig.json ./common/json-data/
 COPY common/json-data/src/ ./common/json-data/src/
-COPY common/validation/package.json common/validation/tsconfig.json ./common/validation/
 COPY common/validation/src/ ./common/validation/src/
-RUN corepack enable && yarn install
 
 FROM backend-base AS backend-build
 WORKDIR /app

--- a/Dockerfile.backend.prod
+++ b/Dockerfile.backend.prod
@@ -1,27 +1,26 @@
+# syntax=docker/dockerfile:1
 ARG NODE_VERSION=24.4.0
 FROM node:${NODE_VERSION}-alpine AS base
 
 FROM base AS backend-build
 ENV NODE_ENV=production
 WORKDIR /app
-# Copy base dependencies
 COPY package.json yarn.lock tsconfig.json .yarnrc.yml ./
 COPY apps/backend/package.json ./apps/backend/
-COPY apps/backend/src/ ./apps/backend/src/
 COPY apps/backend/tsconfig.json ./apps/backend/tsconfig.json
-
 COPY common/json-data/package.json ./common/json-data/
-COPY common/json-data/src/ ./common/json-data/src/
 COPY common/json-data/tsconfig.json ./common/json-data/tsconfig.json
 COPY common/types/package.json ./common/types/
-COPY common/types/src/ ./common/types/src/
 COPY common/types/tsconfig.json ./common/types/tsconfig.json
 COPY common/validation/package.json common/validation/package.json
 COPY common/validation/tsconfig.json common/validation/tsconfig.json
-COPY common/validation/src/ ./common/validation/src/
 
-# Install dependencies
 RUN corepack enable && yarn install
+
+COPY apps/backend/src/ ./apps/backend/src/
+COPY common/json-data/src/ ./common/json-data/src/
+COPY common/types/src/ ./common/types/src/
+COPY common/validation/src/ ./common/validation/src/
 
 RUN yarn workspace @common/json-data build
 RUN yarn workspace @common/types build

--- a/Dockerfile.frontend.dev
+++ b/Dockerfile.frontend.dev
@@ -62,25 +62,13 @@ COPY --from=frontend-dependencies \
 ./
 
 # Copy frontend source files
-COPY --from=frontend-dependencies \
-/app/apps/frontend/ \
-/app/apps/frontend/
-
 COPY apps/frontend/ \
 /app/apps/frontend/
 
 # Copy component source files
-COPY --from=frontend-dependencies \
-/app/components \
-./components
-
 COPY \
 components/ \
 /app/components/
-
-COPY --from=frontend-dependencies \
-/app/common/types \
-./common/types
 
 COPY \
 common/types/ \

--- a/Dockerfile.frontend.prod
+++ b/Dockerfile.frontend.prod
@@ -61,42 +61,21 @@ COPY --from=frontend-dependencies \
 ./
 
 # Copy frontend source files
-COPY --from=frontend-dependencies \
-/app/apps/frontend/ \
-/app/apps/frontend/
-
 COPY apps/frontend/ \
 /app/apps/frontend/
-
-COPY --from=frontend-dependencies \
-/app/common/json-data \
-./common/json-data
 
 COPY \
 common/json-data/ \
 ./common/json-data/
 
 # Copy component source files
-COPY --from=frontend-dependencies \
-/app/components \
-./components
-
 COPY \
 components/ \
 /app/components/
 
-COPY --from=frontend-dependencies \
-/app/common/types \
-./common/types
-
 COPY \
 common/types/ \
 ./common/types/
-
-COPY \
-common/validation/package.json \
-common/validation/tsconfig.json \
-./common/validation/
 
 COPY \
 common/validation/ \

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,7 +1,7 @@
 name: music-discovery-app-prod
 services:
   redis:
-    image: redis:latest
+    image: redis:7.4
     ports:
       - 6379:6379
     networks:
@@ -15,7 +15,7 @@ services:
       retries: 3
   mongo:
     attach: false
-    image: mongo:latest
+    image: mongo:8.0
     ports:
       - 27017:27017
     networks:
@@ -31,7 +31,7 @@ services:
   backend:
     build:
       context: .
-      dockerfile: ./apps/backend/Dockerfile.prod
+      dockerfile: ./Dockerfile.backend.prod
     environment:
       NODE_ENV: production
       DB_HOST: mongo
@@ -60,7 +60,7 @@ services:
   frontend:
     build:
       context: .
-      dockerfile: ./apps/frontend/Dockerfile.prod
+      dockerfile: ./Dockerfile.frontend.prod
     environment:
       NODE_ENV: production
     ports:
@@ -82,8 +82,6 @@ secrets:
 
 networks: # allow services to talk to each other while providing isolation from other docker container, running on the same host
   discovery-network-prod:
-    driver: bridge
-  jenkins:
     driver: bridge
 
 volumes: # enable persistence of database data across container restart

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -24,8 +24,12 @@ services:
       - mongo-data-prod:/data/db
     command: mongod --auth # Enable authentication
     environment:
-      MONGO_INITDB_ROOT_USERNAME: run/secrets/DB_USER
-      MONGO_INITDB_ROOT_PASSWORD: run/secrets/DB_PASSWORD
+      # The official mongo image does not support _FILE-suffix secret injection for
+      # MONGO_INITDB_ROOT_* variables (unlike Postgres). Docker secrets cannot be used
+      # here. Supply DB_USER and DB_PASSWORD via --env-file or as shell env vars when
+      # running in production (e.g. export DB_USER=$(cat ./secrets/DB_USER.txt)).
+      MONGO_INITDB_ROOT_USERNAME: ${DB_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${DB_PASSWORD}
       MONGO_INITDB_DATABASE: music-discovery-app-prod
 
   backend:

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -6,8 +6,6 @@ services:
       - 8080:8080
     networks:
       - discovery-network
-    volumes:
-      - ../data:/data
     command:
       [
         "-scheme",
@@ -28,8 +26,6 @@ services:
       - 5555:5555
     networks:
       - discovery-network
-    volumes:
-      - ../data:/data
     command:
       [
         "-scheme",

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -1,7 +1,7 @@
 services:
   fake-gcs-server:
     attach: false
-    image: fsouza/fake-gcs-server:latest
+    image: fsouza/fake-gcs-server:1.54.0
     ports:
       - 8080:8080
     networks:
@@ -21,7 +21,7 @@ services:
       ]
   fake-gcs-server-external:
     attach: false
-    image: fsouza/fake-gcs-server:latest
+    image: fsouza/fake-gcs-server:1.54.0
     ports:
       - 5555:5555
     networks:
@@ -41,7 +41,7 @@ services:
       ]
 
   mongo:
-    image: mongo:latest
+    image: mongo:8.0
     attach: false
     ports:
       - 27017:27017

--- a/compose.yml
+++ b/compose.yml
@@ -64,6 +64,14 @@ services:
     secrets:
       - SESSION_SECRET
       - RESEND_API_KEY
+    develop:
+      watch:
+        - path: ./common/types/src
+          action: rebuild
+        - path: ./common/validation/src
+          action: rebuild
+        - path: ./common/json-data/src
+          action: rebuild
 
   frontend:
     build:

--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,7 @@ services:
     networks:
       - discovery-network
     volumes:
-      - ../data:/data
+      - fake-gcs-data:/storage
     command:
       [
         "-scheme",
@@ -100,4 +100,6 @@ networks: # allow services to talk to each other while providing isolation from 
 
 volumes: # enable persistence of database data across container restart
   mongo-data:
+    driver: local
+  fake-gcs-data:
     driver: local

--- a/compose.yml
+++ b/compose.yml
@@ -31,6 +31,12 @@ services:
       - discovery-network
     volumes:
       - mongo-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')", "--quiet"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
 
   backend:
     build:
@@ -54,7 +60,8 @@ services:
     networks:
       - discovery-network
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3001/api/v1/health"]
       interval: 10s

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   fake-gcs-server:
-    image: fsouza/fake-gcs-server:latest
+    image: fsouza/fake-gcs-server:1.54.0
     ports:
       - 8080:8080
     networks:
@@ -24,7 +24,7 @@ services:
       ]
   mongo:
     attach: false
-    image: mongo:latest
+    image: mongo:8.0
     ports:
       - 27017:27017
     networks:

--- a/compose.yml
+++ b/compose.yml
@@ -71,9 +71,14 @@ services:
       dockerfile: Dockerfile.frontend.dev
     develop:
       watch:
-        - path: ./components
+        - path: ./components/src
           action: rebuild
-          include: "./components/dist/**"
+        - path: ./common/types/src
+          action: rebuild
+        - path: ./common/validation/src
+          action: rebuild
+        - path: ./common/json-data/src
+          action: rebuild
     volumes:
       - type: bind
         source: ./apps/frontend

--- a/documentation/features/docker-efficiency-update/feature.md
+++ b/documentation/features/docker-efficiency-update/feature.md
@@ -1,0 +1,63 @@
+# Feature Spec: Docker Efficiency Update
+
+## Overview
+
+The project's Docker images and Compose configuration require optimization to reduce friction in local development and improve build reliability. Currently, changes to `@mda/components` or any `@common/*` package require a full container rebuild with no automated trigger — developers must manually rebuild after every workspace package change. In addition, the Dockerfiles and Compose files have not been audited for security hardening or alignment with current Docker conventions. This feature addresses all three concerns: live rebuild on workspace package changes, reduction of unnecessary build work, and a security/convention pass across all Docker configuration.
+
+## Goals
+
+- Developers can change source in `@mda/components` or any `@common/*` workspace package and have the relevant container automatically rebuild and restart without manual intervention.
+- `docker compose up` starts a fully functional local development environment in a single command from a clean clone.
+- All Dockerfiles and Compose files pass a security audit with no critical findings (e.g., no secrets in environment variables, no root-user containers in dev).
+- Docker layer ordering and cache invalidation in all Dockerfiles follows a dependencies-first, source-last pattern so that package installs are not re-run when only source files change.
+- All Compose files reference consistent Dockerfile targets and are internally consistent (no stale paths or mismatched service names).
+
+## Non-goals
+
+- Production deployment infrastructure or CI/CD pipeline changes are out of scope.
+- Reducing cold-build time (first build on a clean machine) is not a goal; only incremental rebuild speed is targeted.
+- Windows or non-Docker local development setups are not addressed.
+
+## User stories
+
+- As a frontend developer, I want changes to `@mda/components` source files to trigger an automatic container rebuild so that I can see updates reflected without running `docker compose build` manually.
+- As a backend developer, I want changes to `@common/types`, `@common/validation`, or `@common/json-data` source files to trigger an automatic rebuild of the backend container so that I am not running stale compiled output.
+- As an engineer setting up the project for the first time, I want `docker compose up --build` to succeed without manual pre-steps so that I can start developing immediately after cloning.
+- As a security-conscious contributor, I want all running containers to use non-root users and to receive secrets through Docker secrets rather than environment variables so that the local environment matches production security posture.
+
+## Functional requirements
+
+### Watch and auto-rebuild
+
+1. The frontend service in `compose.yml` **must** define `develop.watch` rules for `@mda/components` and all `@common/*` packages that trigger a `rebuild` action when source files under their respective `src/` directories change.
+2. The backend service in `compose.yml` **must** define `develop.watch` rules for `@common/types`, `@common/validation`, and `@common/json-data` source directories that trigger a `rebuild` action.
+3. The backend service in `compose.yml` **must not** define `develop.watch` rules for `apps/backend/src`; the existing bind mount combined with `nodemon` (the current `dev` script runner) is sufficient for hot-reload of backend application source.
+
+### Dockerfile layer caching
+
+4. The `# syntax=docker/dockerfile:1` directive **must** be present in all Dockerfiles to enable BuildKit.
+5. All Dockerfiles **must** order `COPY` instructions so that dependency manifests (`package.json`, lock files, config files) are copied and installed before any application source is copied, ensuring `yarn install` layers are not invalidated by source-only changes.
+6. The frontend dev Dockerfile **should** remove the redundant double-copy pattern in the `frontend-build` stage where `COPY --from=<stage> /app/x ./x` is immediately followed by `COPY x/ ./x/`; only the direct `COPY` from the build context is needed.
+7. `corepack enable` **should** appear at most once per Dockerfile stage; it **must not** be repeated across inherited stages.
+
+### Security
+
+8. No container in any Compose file **may** run as `root`; each service **must** use a dedicated non-root user defined in its Dockerfile.
+9. No secrets (session keys, API keys, database credentials) **may** appear as plain `environment` values in any Compose file; they **must** be delivered via Docker secrets or, where Docker secrets are not supported by a service image, the exception **must** be documented inline.
+
+### Compose consistency
+
+10. All Compose files **must** pin third-party service images (`mongo`, `redis`, `fsouza/fake-gcs-server`) to a specific digest-stable version tag rather than `latest`.
+11. `fake-gcs-server` **must** remain in `compose.yml`; `apps/backend/src/cloud/storage.ts` hardcodes `http://fake-gcs-server:8080` as the non-production GCS endpoint and has no env-var override. The `../data` bind mount **must** be replaced with a path inside the repository (or a named volume) so that `docker compose up` succeeds on a clean clone without a pre-existing `../data` directory.
+12. `compose.prod.yml` **must** reference Dockerfiles at the paths declared in the `build.dockerfile` field; the current references (`./apps/backend/Dockerfile.prod`, `./apps/frontend/Dockerfile.prod`) point to paths that do not exist and **must** be corrected.
+13. The `jenkins` network declared in `compose.prod.yml` **must** be removed; it has no attached services and was never used.
+
+## Open questions
+
+None identified.
+
+## Out of scope (deferred)
+
+- Switching from bind mounts to named volumes for improved I/O performance on macOS (Docker Desktop limitation).
+- Multi-platform image builds (`linux/amd64` + `linux/arm64`) for M-series Mac compatibility at the CI layer.
+- Adding a `healthcheck` to the frontend dev service.

--- a/documentation/features/docker-efficiency-update/tasks.md
+++ b/documentation/features/docker-efficiency-update/tasks.md
@@ -1,0 +1,145 @@
+# Implementation Tasks: Docker Efficiency Update
+
+Derived from: `documentation/features/docker-efficiency-update/feature.md`
+
+---
+
+### Task 1: Fix Dockerfile.backend.prod — add BuildKit directive and fix layer ordering
+
+**What:** Adds the `# syntax=docker/dockerfile:1` directive and restructures the `backend-build` stage so that dependency manifests are copied and installed before any source files are copied.
+**Files:** `Dockerfile.backend.prod`
+**Done when:** Line 1 is `# syntax=docker/dockerfile:1`; in the `backend-build` stage all `COPY ... src/` lines appear *after* `RUN corepack enable && yarn install`.
+**Depends on:** none
+**Estimate:** 2
+**Notes:** Currently the file has no syntax directive at all. The `backend-build` stage copies `apps/backend/src/`, `common/*/src/` before running `yarn install`, so any source change busts the install cache. Restructure to: copy all `package.json`/`tsconfig.json`/lockfile manifests → `yarn install` → copy source.
+**Completed:**
+**Implementation notes:**
+
+---
+
+### Task 2: Fix Dockerfile.backend.dev — fix layer ordering in backend-base stage
+
+**What:** Restructures the `backend-base` stage so that source files (`src/`) are copied after `yarn install`, not before.
+**Files:** `Dockerfile.backend.dev`
+**Done when:** In the `backend-base` stage, all `COPY ... src/` lines appear after `RUN corepack enable && yarn install`; the `# syntax=docker/dockerfile:1` directive already present is preserved.
+**Depends on:** none
+**Estimate:** 2
+**Notes:** Same pattern as Task 1 but for the dev Dockerfile. `backend-base` currently copies `apps/backend/src/`, `common/types/src/`, `common/json-data/src/`, `common/validation/src/` before the install step, causing cache busts on every source change. The downstream `backend-build`, `backend-test`, and `backend-dev` stages inherit from `backend-base` so fixing the base fixes all of them.
+**Completed:**
+**Implementation notes:**
+
+---
+
+### Task 3: Fix Dockerfile.frontend.dev — remove redundant double-copy in frontend-build stage
+
+**What:** Removes the `COPY --from=frontend-dependencies` lines in `frontend-build` that are immediately overwritten by a direct `COPY` from the build context.
+**Files:** `Dockerfile.frontend.dev`
+**Done when:** In the `frontend-build` stage, each workspace directory (`apps/frontend/`, `components/`, `common/types/`, `common/json-data/`, `common/validation/`) is copied exactly once (direct `COPY` from build context); no `COPY --from=frontend-dependencies` lines for source directories remain.
+**Depends on:** none
+**Estimate:** 2
+**Notes:** The current pattern is `COPY --from=frontend-dependencies /app/X ./X` immediately followed by `COPY X/ /app/X/`. The second copy overwrites the first completely, so the first adds a redundant layer. Only the manifests/node_modules that come from `frontend-dependencies` (`.yarn`, `node_modules`, `package.json`, `yarn.lock`, `tsconfig.json`) should be copied via `--from=`; all source directories should come directly from the build context.
+**Completed:**
+**Implementation notes:**
+
+---
+
+### Task 4: Fix Dockerfile.frontend.prod — remove redundant double-copy in frontend-build stage
+
+**What:** Applies the same double-copy removal as Task 3 to the production frontend Dockerfile.
+**Files:** `Dockerfile.frontend.prod`
+**Done when:** In the `frontend-build` stage of `Dockerfile.frontend.prod`, each workspace directory is copied exactly once from the build context; no `COPY --from=frontend-dependencies` lines for source directories remain.
+**Depends on:** none
+**Estimate:** 2
+**Notes:** `Dockerfile.frontend.prod` has the same redundant pattern as the dev file. The `common/validation` package is copied three times in the current file (manifests once, then double-copied as source). Remove all redundant intermediate-stage copies for source directories.
+**Completed:**
+**Implementation notes:**
+
+---
+
+### Task 5: Replace `../data` bind mount in compose.yml and compose.test.yml
+
+**What:** Replaces the `../data:/data` volume on `fake-gcs-server` services with a named volume (or a path inside the repository) so that `docker compose up` succeeds on a clean clone.
+**Files:** `compose.yml`, `compose.test.yml`
+**Done when:** Neither `compose.yml` nor `compose.test.yml` contains a volume reference outside the repository root (`../`); running `docker compose up --build` from a fresh clone (with no `../data` directory) does not fail on volume mount errors.
+**Depends on:** none
+**Estimate:** 1
+**Notes:** `compose.yml` uses `-backend filesystem` so it needs persistent storage; use a named Docker volume (e.g. `fake-gcs-data`). `compose.test.yml` uses `-backend memory` so the volume mount is entirely unused and can simply be removed. Both currently reference `../data:/data`.
+**Completed:**
+**Implementation notes:**
+
+---
+
+### Task 6: Add frontend develop.watch rules to compose.yml
+
+**What:** Fixes the existing malformed watch rule and adds `develop.watch` rebuild triggers for all `@common/*` packages on the frontend service.
+**Files:** `compose.yml`
+**Done when:** The `frontend` service has `develop.watch` rules with `action: rebuild` that target `./components/src`, `./common/types/src`, `./common/validation/src`, and `./common/json-data/src`; the incorrect `include: "./components/dist/**"` field (pointing to compiled output, not source) is removed.
+**Depends on:** none
+**Estimate:** 2
+**Notes:** The existing rule watches `./components` but uses `include: "./components/dist/**"` — this watches the build artefact directory, not the source, which defeats the purpose. The `path` for each rule should point to the workspace root (e.g. `./components`) and trigger on any file change within its `src/` subtree; refer to the Compose `develop.watch` docs for the correct `ignore` vs `path` semantics if scoping to `src/` only.
+**Completed:**
+**Implementation notes:**
+
+---
+
+### Task 7: Add backend develop.watch rules to compose.yml
+
+**What:** Adds a `develop.watch` section to the `backend` service that triggers rebuilds on changes to `@common/*` source files, with no watch rule for `apps/backend/src`.
+**Files:** `compose.yml`
+**Done when:** The `backend` service has `develop.watch` entries with `action: rebuild` for `./common/types/src`, `./common/validation/src`, and `./common/json-data/src`; there is no watch rule for `./apps/backend/src`.
+**Depends on:** none
+**Estimate:** 2
+**Notes:** Backend application source (`apps/backend/src`) must explicitly NOT be watched — the bind mount + nodemon already handles hot-reload for that path. Adding a watch rule there would cause redundant full container rebuilds. Only shared workspace package source directories need watch triggers.
+**Completed:**
+**Implementation notes:**
+
+---
+
+### Task 8: Pin third-party image versions in compose.yml and compose.test.yml
+
+**What:** Replaces all `:latest` image tags with specific, stable version tags for `mongo` and `fsouza/fake-gcs-server` in the dev and test Compose files.
+**Files:** `compose.yml`, `compose.test.yml`
+**Done when:** No service in `compose.yml` or `compose.test.yml` uses an image tag of `:latest`; each third-party image specifies a concrete version tag (e.g. `mongo:8.0`, `fsouza/fake-gcs-server:1.49.0`).
+**Depends on:** none
+**Estimate:** 2
+**Notes:** Verify the current stable releases of `mongo` and `fsouza/fake-gcs-server` on Docker Hub before pinning. Choose a patch-level tag that matches what the project has been testing with, or the latest stable minor version. Both images appear in two services in `compose.test.yml` (`fake-gcs-server` and `fake-gcs-server-external`).
+**Completed:**
+**Implementation notes:**
+
+---
+
+### Task 9: Fix compose.prod.yml — correct Dockerfile paths, pin image versions, remove jenkins network
+
+**What:** Corrects the broken Dockerfile references, pins `mongo` and `redis` to stable tags, and removes the unused `jenkins` network declaration.
+**Files:** `compose.prod.yml`
+**Done when:** `backend.build.dockerfile` resolves to an existing file (`./Dockerfile.backend.prod`); `frontend.build.dockerfile` resolves to an existing file (`./Dockerfile.frontend.prod`); neither `mongo` nor `redis` uses `:latest`; the `jenkins` network block is absent from the `networks` section.
+**Depends on:** none
+**Estimate:** 2
+**Notes:** Current paths `./apps/backend/Dockerfile.prod` and `./apps/frontend/Dockerfile.prod` do not exist — the prod Dockerfiles live at the repo root as `Dockerfile.backend.prod` and `Dockerfile.frontend.prod`. The `jenkins` network has no attached services and was never used. Pin `redis` to the same major version currently in use (check Docker Hub for latest stable `redis:7.x` or `redis:8.x`).
+**Completed:**
+**Implementation notes:**
+
+---
+
+### Task 10: Document mongo secrets exception in compose.prod.yml
+
+**What:** Fixes the malformed secret path values in the `mongo` service environment block and adds inline comments documenting why `MONGO_INITDB_ROOT_*` variables cannot use Docker secrets.
+**Files:** `compose.prod.yml`
+**Done when:** The `mongo` service environment values for `MONGO_INITDB_ROOT_USERNAME` and `MONGO_INITDB_ROOT_PASSWORD` are either correctly resolved (actual secret values surfaced via an init script or `--env-file`) or replaced with a documented approach; inline comments explain that the official `mongo` image requires these values as environment variables and cannot read them from Docker secret files at container init time.
+**Depends on:** none
+**Estimate:** 1
+**Notes:** Current values are `run/secrets/DB_USER` and `run/secrets/DB_PASSWORD` — these are literal strings, not secret file reads. The `mongo` service has no `secrets:` block, so Docker is not mounting anything. The official mongo image does not support `_FILE`-suffix secret injection for `MONGO_INITDB_*` vars (unlike e.g. Postgres). Per the spec, when Docker secrets are not supported, the exception must be documented inline.
+**Completed:**
+**Implementation notes:**
+
+---
+
+## Summary
+
+- Total tasks: 10
+- Total estimated effort: 18 points
+- Critical path: No hard blocking dependencies exist between tasks; all can be parallelized. The minimum serial path that unblocks `docker compose up --build` from a clean clone is **Task 5** alone. The minimum path for a fully working watch-and-rebuild loop is **Task 5 → Task 6 → Task 7** (if done by one developer). The minimum path to make `compose.prod.yml` buildable is **Task 9** alone.
+- Risks:
+  - **Task 6 / Task 7 (develop.watch):** The Compose `develop.watch` feature requires Docker Compose v2.22+ and `docker compose watch` or `docker compose up --watch`. Verify the team's Compose version before assuming `watch` is available; the path/action semantics differ from Compose file v2 watch syntax.
+  - **Task 10 (mongo secrets):** The correct long-term fix for mongo init credentials may require an init script approach (`/docker-entrypoint-initdb.d/`), which is a larger change than a comment. Confirm with the team whether a comment-only resolution satisfies the spec or whether an init script is expected.
+  - **Task 8 / Task 9 (image pinning):** Pinning to a specific patch tag locks out security patches until manually updated. Consider whether digest-pinning (`mongo@sha256:...`) is preferred over tag-pinning; the spec says "digest-stable version tag" which may mean either approach.

--- a/documentation/features/docker-efficiency-update/tasks.md
+++ b/documentation/features/docker-efficiency-update/tasks.md
@@ -129,8 +129,8 @@ Derived from: `documentation/features/docker-efficiency-update/feature.md`
 **Depends on:** none
 **Estimate:** 1
 **Notes:** Current values are `run/secrets/DB_USER` and `run/secrets/DB_PASSWORD` — these are literal strings, not secret file reads. The `mongo` service has no `secrets:` block, so Docker is not mounting anything. The official mongo image does not support `_FILE`-suffix secret injection for `MONGO_INITDB_*` vars (unlike e.g. Postgres). Per the spec, when Docker secrets are not supported, the exception must be documented inline.
-**Completed:**
-**Implementation notes:**
+**Completed:** 2026-04-29
+**Implementation notes:** Replaced broken literal strings (`run/secrets/DB_USER`, `run/secrets/DB_PASSWORD`) with Compose variable interpolation (`${DB_USER}`, `${DB_PASSWORD}`) and added a 4-line comment block explaining that the official mongo image does not support `_FILE`-suffix secret injection for `MONGO_INITDB_ROOT_*` vars. Users supply values via `--env-file` or shell env vars referencing the existing `./secrets/` files.
 
 ---
 


### PR DESCRIPTION
This pull request introduces a comprehensive update to the project's Docker and Compose configuration, aimed at improving local development efficiency, build reliability, and security posture. The changes ensure that source code updates in shared workspace packages trigger automatic container rebuilds, Dockerfiles are optimized for better caching, and Compose files are consistent and secure. Additionally, all third-party service images are now pinned to specific versions, and several security and convention improvements have been made.

**Docker and Compose efficiency improvements:**

* Added `develop.watch` rules to `compose.yml` for both backend and frontend services, enabling automatic container rebuilds when source files in `@common/*` or `@mda/components` are changed.
* Updated Dockerfiles to copy dependency manifests before source code, ensuring that `yarn install` layers are cached and only source changes trigger rebuilds. [[1]](diffhunk://#diff-c9ea1fbf7721f08f87d1579fa196a877a8a67263d09e8a37e907de4d4ab88d95R11-L19) [[2]](diffhunk://#diff-92dd70d460610833317eda9680ccf7b16996963479ad26279aa416e78085980aR1-R24)
* Removed redundant `COPY --from=frontend-dependencies` patterns in frontend Dockerfiles, simplifying and streamlining the build process. [[1]](diffhunk://#diff-32f883cf96e51c58ab05dd50b490b90923a522ebca186789ce2890d31198e4bdL65-L84) [[2]](diffhunk://#diff-649f7180c651f5e7831bcb25e77aff3e4967bc03398abdb8bd6aafb351add421L64-L100)

**Security and best practices:**

* Ensured all Compose files pin third-party images (`mongo`, `redis`, `fsouza/fake-gcs-server`) to specific stable versions instead of `latest`. [[1]](diffhunk://#diff-3c22f73b491d3a17d8206e1d06eb996298a8640f24a5b5db28f8d961f9c6771bL4-R4) [[2]](diffhunk://#diff-3c22f73b491d3a17d8206e1d06eb996298a8640f24a5b5db28f8d961f9c6771bL18-R18) [[3]](diffhunk://#diff-70c70fc1bc572d534185ba1c7dda30402d5b56600677a181eeae3511383320c7L4-L10) [[4]](diffhunk://#diff-70c70fc1bc572d534185ba1c7dda30402d5b56600677a181eeae3511383320c7L26-L32) [[5]](diffhunk://#diff-70c70fc1bc572d534185ba1c7dda30402d5b56600677a181eeae3511383320c7L48-R44) [[6]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L3-R9) [[7]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L27-R39)
* Improved secret handling for MongoDB in production by documenting the lack of Docker secret support and requiring environment variables for credentials.
* Removed the unused `jenkins` network from `compose.prod.yml` for clarity and security.

**Reliability and consistency:**

* Corrected Dockerfile paths in `compose.prod.yml` to match actual file locations, ensuring production builds work out of the box. [[1]](diffhunk://#diff-3c22f73b491d3a17d8206e1d06eb996298a8640f24a5b5db28f8d961f9c6771bL27-R38) [[2]](diffhunk://#diff-3c22f73b491d3a17d8206e1d06eb996298a8640f24a5b5db28f8d961f9c6771bL63-R67)
* Added health checks for the `mongo` service and updated `depends_on` conditions to improve service startup reliability in development. [[1]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L27-R39) [[2]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L57-R64)
* Replaced bind mounts for `fake-gcs-server` data with a named volume, so the service works on a clean clone without manual setup. [[1]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588L3-R9) [[2]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R124-R125)

**Documentation:**

* Added a detailed feature spec documenting the motivation, goals, requirements, and scope of the Docker efficiency update.